### PR TITLE
Metrics logging → warn, limited.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-kafka changelog
 ===================
 
+2.4.2
+-----
+
+* limit kafka offset metrics logging
+
 2.4.1
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-kafka changelog
 ===================
 
+2.4.1
+-----
+
+* improved embedded kafka startup time (offset partitions: 50 -> 1)
+
 2.4.0
 -----
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.vladimir-bukhtoyarov</groupId>
+      <artifactId>bucket4j-core</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <optional>true</optional>

--- a/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBroker.java
+++ b/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBroker.java
@@ -142,13 +142,14 @@ public class EmbeddedKafkaBroker implements Closeable
             for (final String topic : topicsToCreate) {
                 while (true) {
                     final List<PartitionInfo> parts = consumer.partitionsFor(topic);
-                    if (parts != null) {
+                    if (parts != null && parts.size() == nPartitions) {
                         break;
                     }
                     loopSleep(start);
                 }
             }
         }
+        LOG.info("topics ready, all having {} partition{}", nPartitions, nPartitions != 1 ? "s" : "");
     }
 
     private void waitForCoordinator(final Instant start) throws InterruptedException {

--- a/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBroker.java
+++ b/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBroker.java
@@ -64,13 +64,17 @@ public class EmbeddedKafkaBroker implements Closeable
     private KafkaServer kafka;
     private int port;
     private final boolean autoCreateTopics;
+    private final int nPartitions;
 
     private Path stateDir;
 
-    protected EmbeddedKafkaBroker(final List<String> topicsToCreate, final boolean autoCreateTopics)
-    {
+    protected EmbeddedKafkaBroker(
+            final List<String> topicsToCreate,
+            final boolean autoCreateTopics,
+            final int nPartitions) {
         this.topicsToCreate = topicsToCreate;
         this.autoCreateTopics = autoCreateTopics;
+        this.nPartitions = nPartitions;
     }
 
     @PostConstruct
@@ -217,7 +221,7 @@ public class EmbeddedKafkaBroker implements Closeable
     }
 
     public void createTopic(String topic) {
-        AdminUtils.createTopic(kafka.zkUtils(), topic, 1, 1, new Properties(), new RackAwareMode.Safe$());
+        AdminUtils.createTopic(kafka.zkUtils(), topic, nPartitions, 1, new Properties(), new RackAwareMode.Safe$());
         LOG.info("Topic {} created", topic);
     }
 

--- a/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBuilder.java
+++ b/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBuilder.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class EmbeddedKafkaBuilder {
     private boolean autoCreateTopics;
     private final List<String> topicsToCreate = new ArrayList<>();
+    private int nPartitions = 1;
 
     public EmbeddedKafkaBuilder withTopics(String... topics) {
         topicsToCreate.addAll(Arrays.asList(topics));
@@ -31,8 +32,13 @@ public class EmbeddedKafkaBuilder {
         return this;
     }
 
+    public EmbeddedKafkaBuilder nPartitions(final int nPartitions) {
+        this.nPartitions = nPartitions;
+        return this;
+    }
+
     EmbeddedKafkaBroker build() {
-        return new EmbeddedKafkaBroker(topicsToCreate, autoCreateTopics);
+        return new EmbeddedKafkaBroker(topicsToCreate, autoCreateTopics, nPartitions);
     }
 
     public EmbeddedKafkaBroker start() {

--- a/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
+++ b/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
@@ -1,0 +1,115 @@
+package com.opentable.kafka.util;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.opentable.kafka.embedded.EmbeddedKafkaBuilder;
+import com.opentable.kafka.embedded.EmbeddedKafkaRule;
+
+public class MultiOffsetMonitorTest {
+    private static final Logger LOG = LoggerFactory.getLogger(MultiOffsetMonitorTest.class);
+
+    private static final String TOPIC_NAME = "test-topic";
+    /** Odd number so they <em>can't</em> be divided evenly between two monitors. */
+    private static final int N_PARTITIONS = 9;
+    private static final String GROUP_ID = "test-group";
+    private static final String NAMESPACE = "test";
+
+    @Rule
+    public final EmbeddedKafkaRule ekr = new EmbeddedKafkaBuilder()
+            .withTopics(TOPIC_NAME)
+            .nPartitions(N_PARTITIONS)
+            .rule();
+
+    /** Test that multiple monitors with the same namespace and attached to the same broker, get the same view. */
+    @Test(timeout = 60_000)
+    public void test() throws InterruptedException, ExecutionException {
+        final String brokerList = ekr.getBroker().getKafkaBrokerConnect();
+
+        // Make consumer that will read from broker.
+        final Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true);
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, (int) Duration.ofSeconds(1).toMillis());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, (int) Duration.ofSeconds(60).toMillis());
+        final Deserializer<byte[]> deser = Serdes.ByteArray().deserializer();
+
+        final Serializer<byte[]> ser = Serdes.ByteArray().serializer();
+
+        try (
+                KafkaProducer<byte[], byte[]> producer = ekr.getBroker().createProducer(ser, ser);
+                KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(props, deser, deser);
+                OffsetMonitor mon1 = new OffsetMonitor(NAMESPACE, brokerList);
+                OffsetMonitor mon2 = new OffsetMonitor(NAMESPACE, brokerList);
+        ) {
+            final List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < 10_000; ++i) {
+                final byte[] key = RandomStringUtils.randomAlphanumeric(20).getBytes(StandardCharsets.UTF_8);
+                final byte[] value = RandomStringUtils.randomAlphanumeric(20).getBytes(StandardCharsets.UTF_8);
+                futures.add(producer.send(new ProducerRecord<>(TOPIC_NAME, key, value)));
+            }
+            for (final Future future : futures) {
+                future.get();
+            }
+
+            Map<Integer, Long> mon1TopicSizes;
+            Map<Integer, Long> mon2TopicSizes;
+            Map<Integer, Long> mon1GroupOffsets;
+            Map<Integer, Long> mon2GroupOffsets;
+
+            // Wait offset record to fill.
+            consumer.subscribe(Collections.singleton(TOPIC_NAME));
+            while (true) {
+                LOG.info("consumed {} records", consumer.poll(Duration.ofSeconds(1).toMillis()).count());
+
+                mon1TopicSizes = mon1.getTopicSizes(TOPIC_NAME);
+                mon2TopicSizes = mon2.getTopicSizes(TOPIC_NAME);
+                mon1GroupOffsets = mon1.getGroupOffsets(GROUP_ID, TOPIC_NAME);
+                mon2GroupOffsets = mon2.getGroupOffsets(GROUP_ID, TOPIC_NAME);
+                LOG.info("key set sizes {} {} {} {}",
+                        mon1TopicSizes.keySet().size(),
+                        mon2TopicSizes.keySet().size(),
+                        mon1GroupOffsets.keySet().size(),
+                        mon2GroupOffsets.keySet().size());
+
+                if (mon1TopicSizes.keySet().size() == N_PARTITIONS &&
+                        mon2TopicSizes.keySet().size() == N_PARTITIONS &&
+                        mon1GroupOffsets.keySet().size() == N_PARTITIONS &&
+                        mon2GroupOffsets.keySet().size() == N_PARTITIONS) {
+                    break;
+                }
+
+                Thread.sleep(Duration.ofSeconds(1).toMillis());
+            }
+
+            Assertions.assertThat(mon1TopicSizes).isEqualTo(mon2TopicSizes);
+            Assertions.assertThat(mon1GroupOffsets).isEqualTo(mon2GroupOffsets);
+
+            Assertions.assertThat(mon1TopicSizes.keySet()).isEqualTo(mon1GroupOffsets.keySet());
+            Assertions.assertThat(mon2TopicSizes.keySet()).isEqualTo(mon2GroupOffsets.keySet());
+        }
+    }
+}

--- a/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
+++ b/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
@@ -80,7 +80,7 @@ public class MultiOffsetMonitorTest {
             Map<Integer, Long> mon1GroupOffsets;
             Map<Integer, Long> mon2GroupOffsets;
 
-            // Wait offset record to fill.
+            // Wait for offset record to fill.
             consumer.subscribe(Collections.singleton(TOPIC_NAME));
             while (true) {
                 LOG.info("consumed {} records", consumer.poll(Duration.ofSeconds(1).toMillis()).count());


### PR DESCRIPTION
[OTPL-1854][1]

So it turns out that the problem was actually not with the offset monitor implementation.  What was actually happening in the chat monitor's case was that the usage was so minimal in QA that only one number was getting regularly sent to.  So we had data on only one of the four partitions.  This meant that the other three partitions eventually lost their offset record (this is expected).  So when the monitor went to probe Kafka to see how far behind the consumer group was, it wasn't getting any data for the other three partitions and consequently declared an error.

This PR updates that log call to be a warning instead of an error. It also updates the logging to be rate limited at a rate of one per ten minutes, with a burst capacity of six.

It also adds a test that did not reproduce the problem, but is probably still useful in its own right.

Further, our embedded Kafka can now be configured to use a non-1 number of partition for its topics.

[1]: https://opentable.atlassian.net/browse/OTPL-1854