### PR TITLE
First pass at Kafka restore listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 otj-kafka changelog
 ===================
+
+2.7.0
+-----
+
+* Add a LogProgressRestoreListener to watch Kafka restore
+
 2.6.1
 -----
 * Spring Boot 2/5.0.4

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-kafka</artifactId>
-  <version>2.6.2-SNAPSHOT</version>
+  <version>2.7.0-SNAPSHOT</version>
   <description>Kafka integrations component</description>
 
   <dependencies>
@@ -69,6 +69,11 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-streams</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/opentable/kafka/util/LogProgressRestoreListener.java
+++ b/src/main/java/com/opentable/kafka/util/LogProgressRestoreListener.java
@@ -1,0 +1,147 @@
+package com.opentable.kafka.util;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.IntStream;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogProgressRestoreListener implements StateRestoreListener, StateListener {
+    private static final Logger LOG = LoggerFactory.getLogger(LogProgressRestoreListener.class);
+
+    @GuardedBy("this")
+    private final Map<String, Partitions> restoreState = new LinkedHashMap<>();
+
+    @GuardedBy("this")
+    private Instant lastPrint = Instant.now(), restoreStart = Instant.now();
+
+    private final StateListener delegate;
+
+    public LogProgressRestoreListener() {
+        this(null);
+    }
+
+    public LogProgressRestoreListener(StateListener delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void onChange(State newState, State oldState) {
+        if (delegate != null) {
+            delegate.onChange(newState, oldState);
+        }
+        if (newState == State.REBALANCING) {
+            LOG.info("Marking beginning of state restore operation");
+            restoreStart = Instant.now();
+        } else if (newState == State.RUNNING && restoreStart != null) {
+            LOG.info("Marking end of restore operation, took {}", Duration.between(restoreStart, Instant.now()));
+            restoreStart = null;
+        }
+    }
+
+    @Override
+    public synchronized void onRestoreStart(TopicPartition topicPartition, String storeName, long startingOffset, long endingOffset) {
+        restoreState.computeIfAbsent(topicPartition.topic(), t -> {
+            LOG.info("Begin restore topic '{}' into store '{}'", t, storeName);
+            return new Partitions();
+        }).onRestoreStart(topicPartition, startingOffset, endingOffset);
+    }
+
+    @Override
+    public synchronized void onRestoreEnd(TopicPartition topicPartition, String storeName, long totalRestored) {
+        final String topic = topicPartition.topic();
+        final Partitions state = restoreState.get(topic);
+        if (state.onRestoreEnd(topicPartition)) {
+            LOG.trace("Completed restore of topic '{}'({}) into store '{}'", topic, totalRestored, storeName);
+        }
+    }
+
+    @Override
+    public synchronized void onBatchRestored(TopicPartition topicPartition, String storeName, long batchEndOffset, long numRestored) {
+        restoreState.get(topicPartition.topic()).onRestore(topicPartition, batchEndOffset);
+        final Instant now = Instant.now();
+        long biggestPartition = 0;
+        if (Duration.between(lastPrint, now).getSeconds() <= 30) {
+            return;
+        }
+        long offsetsSoFar = 0, offsetsTotal = 0;
+        for (Entry<String, Partitions> tp : restoreState.entrySet()) {
+            final Partitions parts = tp.getValue();
+            for (int p = 0; p < parts.offset.length; p++) {
+                offsetsSoFar += parts.offset[p] - parts.start[p];
+                long partitionLen = parts.end[p] - parts.start[p];
+                biggestPartition = Math.max(partitionLen, biggestPartition);
+                offsetsTotal += partitionLen > 0 ? partitionLen : biggestPartition;
+            }
+        }
+        final double ratio = ((double) offsetsSoFar) / offsetsTotal;
+        final Duration eta = Duration.ofMillis((long) (Duration.between(restoreStart, now).toMillis() / ratio));
+        LOG.info("Currently restoring {} topics / {} topic-partitions, {} offsets of {}, {}, since {} ETA {}",
+                restoreState.values().stream().filter(Partitions::isRestoring).count(),
+                restoreState.values().stream().mapToInt(Partitions::countRestoring).sum(),
+                offsetsSoFar,
+                offsetsTotal,
+                String.format("%.2f%%", ratio * 100.0d),
+                restoreStart,
+                eta);
+        lastPrint = now;
+    }
+
+    static class Partitions {
+        // NB this assumes partitions start at 0 and are consecutive.
+        long[] start = new long[0], offset = new long[0], end = new long[0];
+
+        void onRestoreStart(TopicPartition topicPartition, long startingOffset, long endingOffset) {
+            final int partition = ensurePartition(topicPartition);
+            start[partition] = offset[partition] = startingOffset;
+            end[partition] = endingOffset;
+        }
+
+        void onRestore(TopicPartition topicPartition, long batchEndOffset) {
+            offset[topicPartition.partition()] = batchEndOffset;
+        }
+
+        boolean isRestoring() {
+            return countRestoring() > 0;
+        }
+
+        int countRestoring() {
+            int restoring = 0;
+            for (int i = 0; i < offset.length; i++) {
+                if (offset[i] != end[i]) {
+                    restoring++;
+                }
+            }
+            return restoring;
+        }
+
+        boolean onRestoreEnd(TopicPartition topicPartition) {
+            final int partition = topicPartition.partition();
+            offset[partition] = end[partition];
+            return IntStream.range(0, offset.length)
+                    .noneMatch(p -> offset[p] != end[p]);
+        }
+
+        private int ensurePartition(TopicPartition topicPartition) {
+            final int partition = topicPartition.partition();
+            final int partitions = partition + 1;
+            if (offset.length < partitions) {
+                start = Arrays.copyOf(start, partitions);
+                offset = Arrays.copyOf(offset, partitions);
+                end = Arrays.copyOf(end, partitions);
+            }
+            return partition;
+        }
+    }
+}

--- a/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
+++ b/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
@@ -71,7 +71,7 @@ public class MultiOffsetMonitorTest {
                 final byte[] value = RandomStringUtils.randomAlphanumeric(20).getBytes(StandardCharsets.UTF_8);
                 futures.add(producer.send(new ProducerRecord<>(TOPIC_NAME, key, value)));
             }
-            for (final Future future : futures) {
+            for (final Future<?> future : futures) {
                 future.get();
             }
 


### PR DESCRIPTION
This is a first pass at a general progress restore listener for Kafka.
It has a number of limitations, the most obvious being that it generates ETAs with no predictive value, but it is more useful than no restore listener even as is and I don't want to keep the branch open longer.