### PR TITLE
EmbeddedKafka: tune minimum session times to be more appropriate for test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-kafka changelog
 ===================
 
+2.7.1
+-----
+
+* dramatically improve EmbeddedKafka speed for single-broker case
+
 2.7.0
 -----
 

--- a/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBroker.java
+++ b/src/main/java/com/opentable/kafka/embedded/EmbeddedKafkaBroker.java
@@ -203,6 +203,8 @@ public class EmbeddedKafkaBroker implements Closeable
         config.put(KafkaConfig.OffsetsTopicPartitionsProp(), 1);
         config.put(KafkaConfig.OffsetsTopicReplicationFactorProp(), (short) 1);
         config.put(KafkaConfig.AutoCreateTopicsEnableProp(), autoCreateTopics);
+        config.put(KafkaConfig.GroupMinSessionTimeoutMsProp(), 50);
+        config.put(KafkaConfig.GroupInitialRebalanceDelayMsProp(), 50);
         return new KafkaConfig(config);
     }
 


### PR DESCRIPTION
previously, each and every test would wait the full 6s default minimum session timeout