### PR TITLE
Kafka2 [DONT MERGE YET]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ otj-kafka changelog
 
 3.0.0
 -----
-* Requires and supports Kafka 2.0.0
+* **Requires** and supports Kafka 2.0.0
+
+If you want to use Kafka 1.x you need to use an older library version.
 
 2.8.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-kafka changelog
 ===================
 
+3.0.0
+-----
+* Requires and supports Kafka 2.0.0
+
 2.8.3
 -----
 * OffsetMetrics no longer allows metricsPrefix containing period and is always prepended with "kafka."

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>152</version>
+    <version>163</version>
   </parent>
+
 
   <scm>
     <connection>scm:git:git://github.com/opentable/otj-kafka.git</connection>
@@ -29,10 +30,40 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <!-- Remove once otj-parent is updated with this version of otj-metrics, and kafka 2.0.0 -->
+    <dep.kafka.version>2.0.0</dep.kafka.version>
+  </properties>
+
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-kafka</artifactId>
   <version>2.8.4-SNAPSHOT</version>
   <description>Kafka integrations component</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Remove as well -->
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>3.4.13</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -95,11 +126,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/opentable/kafka/partition/InstanceToPartitionMapper.java
+++ b/src/main/java/com/opentable/kafka/partition/InstanceToPartitionMapper.java
@@ -7,5 +7,5 @@ import com.google.common.collect.Multimap;
  */
 @FunctionalInterface
 public interface InstanceToPartitionMapper {
-    Multimap<Integer, Integer> instanceToPartitionMap(final int partitionCount, final int instanceCount);
+    Multimap<Integer, Integer> instanceToPartitionMap(int partitionCount, int instanceCount);
 }

--- a/src/main/java/com/opentable/kafka/util/LogProgressRestoreListener.java
+++ b/src/main/java/com/opentable/kafka/util/LogProgressRestoreListener.java
@@ -75,7 +75,8 @@ public class LogProgressRestoreListener implements StateRestoreListener, StateLi
         if (Duration.between(lastPrint, now).getSeconds() <= 30) {
             return;
         }
-        long offsetsSoFar = 0, offsetsTotal = 0;
+        long offsetsSoFar = 0;
+        long offsetsTotal = 0;
         for (Entry<String, Partitions> tp : restoreState.entrySet()) {
             final Partitions parts = tp.getValue();
             for (int p = 0; p < parts.offset.length; p++) {

--- a/src/test/java/com/opentable/kafka/KafkaBrokerRuleTest.java
+++ b/src/test/java/com/opentable/kafka/KafkaBrokerRuleTest.java
@@ -15,6 +15,7 @@ package com.opentable.kafka;
 
 import static org.junit.Assert.assertEquals;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -47,7 +48,7 @@ public class KafkaBrokerRuleTest {
 
         try (KafkaConsumer<String, String> consumer = ekb.createConsumer("test")) {
             consumer.subscribe(Collections.singletonList(TEST_TOPIC));
-            ConsumerRecords<String, String> records = consumer.poll(5000);
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(5));
             assertEquals(1, records.count());
             assertEquals(TEST_VALUE, records.iterator().next().value());
         }

--- a/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
+++ b/src/test/java/com/opentable/kafka/util/MultiOffsetMonitorTest.java
@@ -83,7 +83,7 @@ public class MultiOffsetMonitorTest {
             // Wait for offset record to fill.
             consumer.subscribe(Collections.singleton(TOPIC_NAME));
             while (true) {
-                LOG.info("consumed {} records", consumer.poll(Duration.ofSeconds(1).toMillis()).count());
+                LOG.info("consumed {} records", consumer.poll(Duration.ofSeconds(1)).count());
 
                 mon1TopicSizes = mon1.getTopicSizes(TOPIC_NAME);
                 mon2TopicSizes = mon2.getTopicSizes(TOPIC_NAME);

--- a/src/test/java/com/opentable/kafka/util/ReadWriteRule.java
+++ b/src/test/java/com/opentable/kafka/util/ReadWriteRule.java
@@ -79,7 +79,7 @@ final class ReadWriteRule extends ExternalResource implements Closeable, AutoClo
             consumer.subscribe(Collections.singleton(ReadWriteRule.TOPIC_NAME));
             ConsumerRecords<String, String> records;
             while (true) {
-                records = consumer.poll(POLL_TIME.toMillis());
+                records = consumer.poll(POLL_TIME);
                 if (!records.isEmpty()) {
                     break;
                 }


### PR DESCRIPTION
This has been labeled 3.0.0 because it supports ONLY Kafka 2.0.0, and once added to otj-parent will be a point of no return. 
* Spring Boot 2.1 uses Kafka 2.0.0 so we'll have to switch then regardless (probably)

Once this is merged and released, you'll be able to test your app against Kafka 2, using the following
* Upgrade to POM 171 (strictly speaking not 100% necessary, but recommended so we have a baseline)
* Add a dependency management entry, forcing otj-kafka 3.0.0
* Add the following to your POM properties
<dep.kafka.version>2.0.0</dep.kafka.version>
* Check to see indeed that your dependency tree is pulling pure kafka 2.0.0
* You may need to also add the dependency management in the otj-kafka POM that adds the zookeeper version change. Let me know if this was needed.

Major changes in Kafka 2.0.0
* All over the place but
* Kafka Streams - supposedly a lot of jiggering here
* All the poll timeouts etc are now deprecated in favor using Duration (yay)
* Significant refactoring and improvements in the (now official Java) Admin Client

**I need folks to test this once it's approved and released. LMK if you know others that should be on the review list**