### PR TITLE
include the right versions of metrics and conserved headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-kafka changelog
 ===================
 
+3.1.0
+-----
+* Uses otj-metrics 3.0
+
 3.0.0
 -----
 * **Requires** and supports Kafka 2.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>163</version>
+    <version>179</version>
   </parent>
 
 
@@ -31,8 +31,7 @@
   </scm>
 
   <properties>
-    <!-- Remove once otj-parent is updated with this version of otj-metrics, and kafka 2.0.0 -->
-    <dep.kafka.version>2.0.0</dep.kafka.version>
+    <dep.otj-metrics.version>3.0.0</dep.otj-metrics.version>
   </properties>
 
   <groupId>com.opentable.components</groupId>
@@ -80,7 +79,8 @@
     </dependency>
     <dependency>
       <groupId>com.opentable.components</groupId>
-      <artifactId>otj-metrics</artifactId>
+      <artifactId>otj-metrics-core</artifactId>
+      <version>${dep.otj-metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>com.opentable.components</groupId>

--- a/src/main/java/com/opentable/kafka/util/LogProgressRestoreListener.java
+++ b/src/main/java/com/opentable/kafka/util/LogProgressRestoreListener.java
@@ -24,7 +24,8 @@ public class LogProgressRestoreListener implements StateRestoreListener, StateLi
     private final Map<String, Partitions> restoreState = new LinkedHashMap<>();
 
     @GuardedBy("this")
-    private Instant lastPrint = Instant.now(), restoreStart = Instant.now();
+    private Instant lastPrint = Instant.now();
+    private Instant restoreStart = Instant.now();
 
     private final StateListener delegate;
 
@@ -101,7 +102,9 @@ public class LogProgressRestoreListener implements StateRestoreListener, StateLi
 
     static class Partitions {
         // NB this assumes partitions start at 0 and are consecutive.
-        long[] start = new long[0], offset = new long[0], end = new long[0];
+        long[] start = new long[0];
+        long[] offset = new long[0];
+        long[] end = new long[0];
 
         void onRestoreStart(TopicPartition topicPartition, long startingOffset, long endingOffset) {
             final int partition = ensurePartition(topicPartition);


### PR DESCRIPTION
@dkaukov Updating this too, will update otj-parent to reflect