### PR TITLE
Be able to Change the sampling bucket

### DIFF
--- a/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaBaseBuilder.java
+++ b/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaBaseBuilder.java
@@ -99,7 +99,8 @@ class KafkaBaseBuilder {
             addProperty(LoggingInterceptorConfig.SAMPLE_RATE_PCT_CONFIG, loggingSampleRate);
             addProperty(LoggingInterceptorConfig.SAMPLE_RATE_BUCKET_SECONDS_CONFIG, loggingDenominator);
             addProperty(LoggingInterceptorConfig.SAMPLE_RATE_TYPE_CONFIG, loggingSamplerType.getValue());
-            LOG.debug("Setting sampler {} - {}", loggingSamplerType, loggingSampleRate);
+            LOG.debug("Setting sampler {} - {}, {} second bucket ", loggingSamplerType, loggingSampleRate,
+                    loggingSamplerType == SamplerType.TimeBucket ? loggingDenominator : "--NA--");
         }
     }
 

--- a/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaBaseBuilder.java
+++ b/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaBaseBuilder.java
@@ -56,6 +56,7 @@ class KafkaBaseBuilder {
     private final List<String> interceptors = new ArrayList<>();
     private boolean enableLoggingInterceptor = true;
     private int loggingSampleRate = LoggingInterceptorConfig.DEFAULT_SAMPLE_RATE_PCT;
+    private int loggingDenominator = LoggingInterceptorConfig.DEFAULT_BUCKET_DENOMINATOR;
     private Optional<String> metricsPrefix = Optional.empty();
     private SamplerType loggingSamplerType = SamplerType.TimeBucket;
     private OptionalLong requestTimeout = OptionalLong.empty();
@@ -91,8 +92,12 @@ class KafkaBaseBuilder {
         // Copy over any injected properties, then remove the seed property
         List<String> merged = merge(interceptors, interceptorConfigName);
         if (merged.contains(loggingInterceptorName)) {
+            if (loggingDenominator <= 0) {
+                throw new IllegalArgumentException("LoggingDenominator must be > 0");
+            }
             addProperty(LoggingInterceptorConfig.LOGGING_ENV_REF, environmentProvider);
             addProperty(LoggingInterceptorConfig.SAMPLE_RATE_PCT_CONFIG, loggingSampleRate);
+            addProperty(LoggingInterceptorConfig.SAMPLE_RATE_BUCKET_SECONDS_CONFIG, loggingDenominator);
             addProperty(LoggingInterceptorConfig.SAMPLE_RATE_TYPE_CONFIG, loggingSamplerType.getValue());
             LOG.debug("Setting sampler {} - {}", loggingSamplerType, loggingSampleRate);
         }
@@ -156,8 +161,9 @@ class KafkaBaseBuilder {
     void withLogging(boolean enabled) {
         enableLoggingInterceptor = enabled;
     }
-    void withSamplingRatePer10Seconds(final int rate) {
+    void withBucketedSamplingRate(final int rate, final int denominator) {
         loggingSampleRate = rate;
+        loggingDenominator = denominator;
         loggingSamplerType = SamplerType.TimeBucket;
     }
     void withRandomSamplingRate(final int rate) {

--- a/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaConsumerBuilder.java
+++ b/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaConsumerBuilder.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import com.opentable.kafka.logging.LoggingConsumerInterceptor;
+import com.opentable.kafka.logging.LoggingInterceptorConfig;
 
 /**
  * Main builder for KafkaConsumer. This is usually entered via a KafkaConsumerBuilderFactoryBean so some "sugar" is injected.
@@ -88,7 +89,12 @@ public class KafkaConsumerBuilder<K, V>  {
     }
 
     public KafkaConsumerBuilder<K, V> withSamplingRatePer10Seconds(int rate) {
-        kafkaBaseBuilder.withSamplingRatePer10Seconds(rate);
+        kafkaBaseBuilder.withBucketedSamplingRate(rate, LoggingInterceptorConfig.DEFAULT_BUCKET_DENOMINATOR);
+        return this;
+    }
+
+    public KafkaConsumerBuilder<K, V> withSamplingRatePerNSeconds(int rate, int nSeconds) {
+        kafkaBaseBuilder.withBucketedSamplingRate(rate, nSeconds);
         return this;
     }
 

--- a/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaProducerBuilder.java
+++ b/otj-kafka/src/main/java/com/opentable/kafka/builders/KafkaProducerBuilder.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.Serializer;
 
+import com.opentable.kafka.logging.LoggingInterceptorConfig;
 import com.opentable.kafka.logging.LoggingProducerInterceptor;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -93,8 +94,14 @@ public class KafkaProducerBuilder<K, V> {
 
 
     public KafkaProducerBuilder<K, V> withSamplingRatePer10Seconds(int rate) {
-        kafkaBaseBuilder.withSamplingRatePer10Seconds(rate);
+        kafkaBaseBuilder.withBucketedSamplingRate(rate, LoggingInterceptorConfig.DEFAULT_BUCKET_DENOMINATOR);
         return this;
+    }
+
+    public KafkaProducerBuilder<K, V> withSamplingRatePerNSeconds(int rate, int nSeconds) {
+        kafkaBaseBuilder.withBucketedSamplingRate(rate, nSeconds);
+        return this;
+
     }
 
     public KafkaProducerBuilder<K, V> withRandomSamplingRate(int rate) {

--- a/otj-kafka/src/main/java/com/opentable/kafka/logging/LogSampler.java
+++ b/otj-kafka/src/main/java/com/opentable/kafka/logging/LogSampler.java
@@ -55,13 +55,14 @@ public abstract class LogSampler {
         private final Optional<LocalBucket> bucket;
 
         LogSamplerBucket(LoggingInterceptorConfig conf) {
-            final Integer howOftenPer10Seconds = conf.getInt(LoggingInterceptorConfig.SAMPLE_RATE_PCT_CONFIG);
+            final Integer howOftenPerNSEconds = conf.getInt(LoggingInterceptorConfig.SAMPLE_RATE_PCT_CONFIG);
+            final Integer nSeconds = conf.getInt(LoggingInterceptorConfig.SAMPLE_RATE_BUCKET_SECONDS_CONFIG);
             Bandwidth limit;
-            if (howOftenPer10Seconds == null || howOftenPer10Seconds < 0) {
+            if (howOftenPerNSEconds == null || howOftenPerNSEconds < 0) {
                 LOG.warn("Not rate limiting");
                 this.bucket = Optional.empty();
             } else {
-                limit = Bandwidth.simple(howOftenPer10Seconds, Duration.ofSeconds(10));
+                limit = Bandwidth.simple(howOftenPerNSEconds, Duration.ofSeconds(nSeconds));
                 this.bucket = Optional.ofNullable(Bucket4j.builder().addLimit(limit).build());
             }
         }

--- a/otj-kafka/src/main/java/com/opentable/kafka/logging/LoggingInterceptorConfig.java
+++ b/otj-kafka/src/main/java/com/opentable/kafka/logging/LoggingInterceptorConfig.java
@@ -38,13 +38,19 @@ public class LoggingInterceptorConfig extends AbstractConfig {
     // Whether to stop header propagation
     public static final String ENABLE_HEADER_PROPAGATION_CONFIG = "ot.logging.headers";
 
+    public static final String SAMPLE_RATE_BUCKET_SECONDS_CONFIG = "ot.logging.rate.bucket";
+
+    public static final int DEFAULT_BUCKET_DENOMINATOR = 10;
+
     private static final ConfigDef CONFIG = new ConfigDef()
             .define(SAMPLE_RATE_PCT_CONFIG, Type.INT, DEFAULT_SAMPLE_RATE_PCT, ConfigDef.Importance.LOW,
-                    "Logging limit rate per 10 seconds for time-bucket or percent of records for random sampler. Use a negative value to disable limiting (lots of logs!) ")
+                    "Logging limit rate per N seconds for time-bucket or percent of records for random sampler, where N = SAMPLE_RATE_BUCKET_SECONDS_CONFIG. Use a negative value to disable limiting (lots of logs!) ")
             .define(SAMPLE_RATE_TYPE_CONFIG, Type.STRING, DEFAULT_SAMPLE_RATE_TYPE, ConfigDef.Importance.LOW,
                     "Logging sampler type. Possible values: (random, time-bucket)")
             .define(ENABLE_HEADER_PROPAGATION_CONFIG, Type.STRING, GenerateHeaders.ALL.name(),
                     ConfigDef.Importance.LOW, "Whether to use headers for propagation")
+            .define(SAMPLE_RATE_BUCKET_SECONDS_CONFIG, Type.INT,  DEFAULT_BUCKET_DENOMINATOR, ConfigDef.Importance.LOW,
+                    "How large is the token bucket? The default is 10 seconds")
             ;
 
     LoggingInterceptorConfig(Map<String, ?> originals) {


### PR DESCRIPTION
We started withh the assumption of two models

1. Flip a coin and match the %. This works, but on high volume can over log
2. Token Bucket. We assumed 1 per 10 seconds was as low as folks wanted.

Emanuel has come up with arguments that he wants to log but less commonly.
He can either use 1) with a low % and hope his volume doesn't log too often ;)
or 2) we can expose the ability to define the bucket rate.

I've done the latter. I added the signature withSamplingRatePerNSeconds which takes both the rate, and the bucket. So you could do things like

rate = 1
bucket = 1000
(only log once per 1000 seconds (eg every 15 minutes or so)