### PR TITLE
Move session tests from ot-eda-java

### DIFF
--- a/otj-kafka/src/test/java/com/opentable/kafka/session/BaseSessionScaffold.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/BaseSessionScaffold.java
@@ -1,0 +1,93 @@
+package com.opentable.kafka.session;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.opentable.kafka.builders.KafkaConsumerBaseBuilder;
+import com.opentable.kafka.builders.KafkaConsumerBuilder;
+import com.opentable.kafka.builders.KafkaProducerBuilder;
+import com.opentable.kafka.builders.SettableEnvironmentProvider;
+import com.opentable.kafka.embedded.EmbeddedKafkaBroker;
+
+// Class provides a broker, eventbus, before and after semantics, and basic builders
+public abstract class BaseSessionScaffold {
+    protected static final Logger LOG = LoggerFactory.getLogger(BaseSessionScaffold.class);
+
+    protected static final String TEST_TOPIC = "testing";
+
+    protected EmbeddedKafkaBroker embeddedKafkaBroker;
+    protected EventBus<String> eventBus;
+
+    public abstract BiConsumer<Runnable, Consumer<Integer, String>> getConsumerRecoveryLambda();
+    @Before
+    public void before() {
+        eventBus = new EventBus<>();
+        // Create the embedded kafka, precreate topic, and set partitions to 32.
+        embeddedKafkaBroker =  new EmbeddedKafkaBroker(Collections.singletonList(TEST_TOPIC), true, 32);
+        embeddedKafkaBroker.start();
+    }
+
+    @After
+    public void after() {
+        embeddedKafkaBroker.close();
+    }
+
+    protected ProducerTask getProducerTask(final Producer<Integer, String> producer, Integer maxRecords) {
+        return new ProducerTask(producer, TEST_TOPIC, maxRecords);
+    }
+
+    protected ConsumerTask<String> getConsumerTask(final Consumer<Integer, String> consumer, Integer sleepPoint) {
+        return new ConsumerTask<>(eventBus, consumer, TEST_TOPIC, sleepPoint, getConsumerRecoveryLambda());
+    }
+
+    protected Producer<Integer, String> producer() {
+        return producerBuilder()
+                .withSerializers(IntegerSerializer.class, StringSerializer.class)
+                .withBootstrapServer(embeddedKafkaBroker.getKafkaBrokerConnect())
+                .withClientId(UUID.randomUUID().toString()) // each producer is unique
+                .disableLogging()
+                .disableMetrics()
+                .build();
+    }
+
+    protected Consumer<Integer, String> consumer(int consumerNumber, String groupId) {
+        return consumerBuilder()
+                .withDeserializers(IntegerDeserializer.class, StringDeserializer.class)
+                .withGroupId(groupId) // force new offset management
+                .withBootstrapServer(embeddedKafkaBroker.getKafkaBrokerConnect())
+                .withAutoCommit(true)
+                .withProperty(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 1000)
+                .withClientId("consumer-" + consumerNumber) // each is tied to the consumer number
+                .withMaxPollRecords(1) // 1 each time we poll makes book keeping much easier.
+                // Seems to take in the output log, and should cause rebalance shortly after 10s
+                .withSessionTimeoutMs(Duration.ofSeconds(10))
+                .withProperty("max.poll.interval.ms", (int) Duration.ofSeconds(11).toMillis())
+                .withAutoOffsetReset(KafkaConsumerBaseBuilder.AutoOffsetResetType.Earliest)
+                .disableLogging()
+                .disableMetrics()
+                .build();
+    }
+
+    public KafkaConsumerBuilder<Integer, String> consumerBuilder() {
+        return new KafkaConsumerBuilder<>(new HashMap<>(), new SettableEnvironmentProvider("","",1,"",""));
+    }
+
+    public KafkaProducerBuilder<Integer, String> producerBuilder() {
+        return new KafkaProducerBuilder<>(new HashMap<>(), new SettableEnvironmentProvider("", "", 1, "", ""));
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/BaseSessionTest.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/BaseSessionTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.kafka.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.junit.Ignore;
+import org.junit.Test;
+
+// Actual base tests are here
+public abstract class BaseSessionTest extends BaseSessionScaffold {
+    public abstract BiConsumer<Runnable, Consumer<Integer, String>> getConsumerRecoveryLambda();
+    public abstract void moreAssertionsForTestResult(final boolean withSleep, final TestResult testResult, final long expectedTotalMessages, final long expectedRevocations);
+    // Shows a simple one consumer processes as expected.
+    // These have single producer/consumer, with bounded message count
+    @Test(timeout = 15000L)
+    public void testSimpleNoStrategy() throws ExecutionException, InterruptedException {
+        final int totalMessages = 100;
+        final TestResult simpleTestResult = commonSimpleTests(totalMessages, totalMessages * 10);
+        final List<ConsumedEvent.EventType> eventTypes = commonSimpleAssertions(false, simpleTestResult, totalMessages);
+        assertThat(eventTypes).doesNotContain(ConsumedEvent.EventType.ABOUT_TO_SLEEP, ConsumedEvent.EventType.WAKING_UP);
+    }
+
+    // Shows a simple one consumer processes as expected, even after losing partitions
+    // These have single producer/consumer, with bounded message count
+    @Test(timeout = 35000L)
+    @Ignore
+    public void testSimpleWithStategy() throws ExecutionException, InterruptedException {
+        final TestResult simpleTestResult = commonSimpleTests(100, 20);
+        // Note the batch of 20 gets repeated.
+        final List<ConsumedEvent.EventType> eventTypes = commonSimpleAssertions(true, simpleTestResult, 100 + 20);
+        assertThat(eventTypes).containsOnlyOnce(ConsumedEvent.EventType.ABOUT_TO_SLEEP, ConsumedEvent.EventType.WAKING_UP);
+    }
+
+    private List<ConsumedEvent.EventType> commonSimpleAssertions(boolean withSleep, TestResult simpleTestResult, int totalMessages) {
+        List<ConsumedEvent.EventType> eventTypes = simpleTestResult.getEvents().stream().map(ConsumedEvent::getEventType).collect(Collectors.toList());
+        // Once per consumer task
+        LOG.info("EventTypes: \n{}", new HashSet<>(eventTypes));
+        assertThat(eventTypes).containsOnlyOnce(ConsumedEvent.EventType.SUBSCRIBED, ConsumedEvent.EventType.CLOSING);
+        assertThat(eventTypes.stream().filter(t -> t == ConsumedEvent.EventType.POLL).count()).isGreaterThanOrEqualTo(totalMessages);
+
+        // Has consumed a total of N messages
+        assertThat(eventTypes.stream().filter(t -> t == ConsumedEvent.EventType.POLL).count()).isGreaterThanOrEqualTo(totalMessages);
+        moreAssertionsForTestResult(withSleep, simpleTestResult, (long) totalMessages, withSleep ? 1L : 0L);
+        return eventTypes;
+    }
+
+    private TestResult commonSimpleTests(int totalMessages, int sleepCount) throws ExecutionException, InterruptedException {
+        final Producer<Integer, String> producer = producer();
+        final Consumer<Integer, String> consumer = consumer(1, UUID.randomUUID().toString());
+        EventBus.Listener<String> listener = new SimpleBoundedListener<String>(totalMessages, consumer);
+        eventBus.addListener(listener);
+
+        final ProducerTask producerTask = getProducerTask(producer, totalMessages);
+        final ConsumerTask<String> consumerTask = getConsumerTask(consumer, sleepCount);
+        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        Future<?> producerFuture =  executorService.submit(producerTask);
+        Future<?> consumerFuture = executorService.submit(consumerTask);
+        // We can simply complete since producer is bounded
+        producerFuture.get();
+        LOG.info("Producer future completed");
+        // The consumer cascades from the BoundedListener
+        consumerFuture.get();
+        executorService.shutdownNow();
+        List<ConsumedEvent<String>> events = eventBus.getEvents().stream().sorted(Comparator.comparing(ConsumedEvent::getMessageNumber)).collect(Collectors.toList());
+        LOG.warn("Events: {}", events.size());
+        events.forEach(t -> LOG.info(t.toString()));
+
+        return new TestResult(Collections.singletonList(consumerTask), events, producerTask);
+    }
+
+    // Same as the simple test, but with 3 consumers
+    // Total messages remains bounded, and no sleep, so under normal circumstances no rebalance
+    @Test(timeout = 15000)
+    @Ignore
+    public void complexTestWithNoStrategy() throws ExecutionException, InterruptedException {
+        final int totalMessages = 100;
+        TestResult complexTestResult = commonComplexTestsWithSleep(totalMessages, 110000, 3);
+        List<ConsumedEvent<String>> events = complexTestResult.getEvents();
+        assertThat(complexTestResult.getProducerTask().getTotalMessages()).isEqualTo(totalMessages);
+        Set<ConsumedEvent.EventType> eventTypeList = events.stream().map(ConsumedEvent::getEventType).collect(Collectors.toSet());
+        List<ConsumedEvent<String>> messageEvents = events.stream().filter(t -> t.getEventType() == ConsumedEvent.EventType.MESSAGE).sorted(Comparator.comparing(t -> t.getMessageNumber())).collect(Collectors.toList());
+        Set<UUID> consumerIds = messageEvents.stream().map(ConsumedEvent::getConsumerId).collect(Collectors.toSet());
+        assertThat(consumerIds).hasSize(3);
+        assertThat(eventTypeList).containsOnly(ConsumedEvent.EventType.SUBSCRIBED, ConsumedEvent.EventType.MESSAGE, ConsumedEvent.EventType.CLOSING, ConsumedEvent.EventType.POLL);
+        moreAssertionsForTestResult(false, complexTestResult,100L,0L);
+    }
+
+    // Unbounded producer (see ComplexPotentiallyUnBoundedListener for the cascaded logic that causes a termination)
+    // multiple consumers
+    // One consumer will sleep beyond session.timeout.ms
+    @Test(timeout = 35000)
+    @Ignore
+    public void complexTestWithStrategy() throws ExecutionException, InterruptedException {
+        // We don't bound the totalMessages, instead we rely on the complex cascade in ComplexBoundedListener.
+        Integer initialTotalMessages = null;
+        // Sleep at item # 50 consumed for consumer #1. Create 3 consumers
+        TestResult complexTestResult = commonComplexTestsWithSleep(initialTotalMessages, 50, 3);
+        List<ConsumedEvent<String>> events = complexTestResult.getEvents();
+        int totalMessages = complexTestResult.getProducerTask().getTotalMessages() + 50;
+        Set<ConsumedEvent.EventType> eventTypeList = events.stream().map(ConsumedEvent::getEventType).collect(Collectors.toSet());
+        List<ConsumedEvent<String>> messageEvents = events.stream().filter(t -> t.getEventType() == ConsumedEvent.EventType.MESSAGE).sorted(Comparator.comparing(t -> t.getMessageNumber())).collect(Collectors.toList());
+        Set<UUID> consumerIds = messageEvents.stream().map(ConsumedEvent::getConsumerId).collect(Collectors.toSet());
+
+        // All the events we expected
+        assertThat(eventTypeList).contains(ConsumedEvent.EventType.POLL, ConsumedEvent.EventType.CLOSING, ConsumedEvent.EventType.SUBSCRIBED, ConsumedEvent.EventType.WAKING_UP, ConsumedEvent.EventType.ABOUT_TO_SLEEP);
+       // assertThat(messageEvents).hasSize(totalMessages);
+        assertThat(consumerIds).hasSize(3);
+
+        // Prove we continued to get messages
+        int countOfAboutToPause = 0;
+        int indexOfAboutToWakeup = -1;
+        int countOfAboutToWakeup = 0;
+        UUID consumerIdWakingUp = null;
+        for (int i =0; i< events.size() ; i++) {
+            ConsumedEvent<String> event = events.get(i);
+            switch (event.getEventType()) {
+                case ABOUT_TO_SLEEP: {
+                    countOfAboutToPause++;
+                    break;
+                }
+                case WAKING_UP: {
+                    if (countOfAboutToPause > 0) {
+                        countOfAboutToWakeup++;
+                        consumerIdWakingUp = event.getConsumerId();
+                        indexOfAboutToWakeup = i;
+                    }
+                    break;
+                }
+            }
+        }
+        assertThat(countOfAboutToPause).isEqualTo(1);
+        assertThat(countOfAboutToWakeup).isEqualTo(1);
+        assertThat(consumerIdWakingUp).isNotNull();
+        assertThat(indexOfAboutToWakeup).isGreaterThan(-1);
+        List<ConsumedEvent<String>> eventsAfterIndex = events.subList(indexOfAboutToWakeup + 1, events.size());
+        final UUID c = consumerIdWakingUp;
+        List<ConsumedEvent<String>> messageEventsAfterWakingUp = eventsAfterIndex.stream().filter(t -> t.getConsumerId().equals(c)).filter(t -> t.getEventType() == ConsumedEvent.EventType.MESSAGE).collect(Collectors.toList());
+        assertThat(messageEventsAfterWakingUp.size()).isGreaterThan(0);
+        moreAssertionsForTestResult(true, complexTestResult, (long) totalMessages, 1L);
+ }
+
+    private TestResult commonComplexTestsWithSleep(Integer totalMessages, int sleepCount, int consumerCount) throws ExecutionException, InterruptedException {
+        final Producer<Integer, String> producer = producer();
+        final List<Consumer<Integer, String>> consumerList = new ArrayList<>();
+        final UUID groupId = UUID.randomUUID();
+
+        // Create consumerCount total Consumers
+        for (int i = 1; i <= consumerCount; i++) {
+            final Consumer<Integer, String> consumer = consumer(i, groupId.toString());
+            consumerList.add(consumer);
+        }
+
+        final ProducerTask producerTask = getProducerTask(producer, totalMessages);
+        final EventBus.Listener<String> listener = new ComplexPotentiallyUnBoundedListener<>(
+                totalMessages, consumerList, producerTask);
+        eventBus.addListener(listener);
+
+        // Create consumerCount total consumerTasks
+        final List<ConsumerTask<String>> consumerTaskList = new ArrayList<>();
+        for (int i = 1; i <= consumerCount; i++) {
+            // Only attach to one of the consumers, the others will pound away
+            if (i == 1) {
+                final ConsumerTask<String> consumerTask = getConsumerTask(
+                        consumerList.get(i - 1), sleepCount);
+                consumerTaskList.add(consumerTask);
+                continue;
+            }
+            // These will either be set higher than bound (if bounded)
+            // or null, which disables sleeping altogether
+            // Net effect is only the i==1 consumer is eligible for sleeping
+            final ConsumerTask<String> consumerTask = getConsumerTask(
+                    consumerList.get(i - 1), totalMessages == null ? null : totalMessages * 10);
+            consumerTaskList.add(consumerTask);
+        }
+        assertThat(consumerTaskList).hasSize(consumerCount);
+
+        // Allocate consumerCount + 1 producer thread.
+        final ExecutorService executorService = Executors.newFixedThreadPool(consumerCount + 1);
+        Future<?> producerFuture =  executorService.submit(producerTask);
+
+        // Create consumerCount total futures....
+        List<Future<?>> consumerFutureList = new ArrayList<>();
+        for (int i = 1; i <= consumerCount; i++) {
+            Future<?> consumerFuture = executorService.submit(consumerTaskList.get(i -1));
+            consumerFutureList.add(consumerFuture);
+        }
+
+        // We can simply complete since producer is bounded or cascades from ComplexBoundedListener
+        producerFuture.get();
+        LOG.info("Producer future completed");
+        // The consumer cascades from the ComplexBoundedListener
+        for (int i = 1; i< consumerCount; i++) {
+            consumerFutureList.get(i - 1).get();
+        }
+        executorService.shutdownNow();
+        List<ConsumedEvent<String>> events = eventBus.getEvents();
+        LOG.info("Events: {} ",  events);
+        return new TestResult(consumerTaskList, events, producerTask);
+    }
+
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/ComplexPotentiallyUnBoundedListener.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/ComplexPotentiallyUnBoundedListener.java
@@ -1,0 +1,92 @@
+package com.opentable.kafka.session;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A more complex algorithm that assumes
+ * - only Zero/one wakeup
+ * - either a nonnull totalMessages in constructor
+ * - OR a WAKEUP occures
+ * - For a wakeup, this triggers a watch for a message
+ * from same consumer, which in turn triggers a shut down of the producer.
+ * which in turn waits for the remainder to be consumed.
+ * @param <T>
+ */
+public class ComplexPotentiallyUnBoundedListener<T> implements EventBus.Listener<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(ComplexPotentiallyUnBoundedListener.class);
+    private volatile Integer totalMessages;
+    private final List<Consumer<Integer, String>> consumers;
+    private final Set<Integer> processedMessages = ConcurrentHashMap.newKeySet();
+    private final AtomicReference<UUID> consumerIdThatWokeup = new AtomicReference<>();
+    private final ProducerTask producerTask;
+
+    public ComplexPotentiallyUnBoundedListener(Integer totalMessages, List<Consumer<Integer, String>> consumers, ProducerTask producerTask) {
+        this.totalMessages = totalMessages;
+        this.consumers = consumers;
+        this.producerTask = producerTask;
+    }
+    @Override
+    public synchronized void listen(final ConsumedEvent<T> event) {
+        LOG.debug("listener: {}", event);
+        int messageNumber = event.getMessageNumber();
+        switch (event.getEventType()) {
+            case MESSAGE: {
+                if (messageNumber > 0) {
+                    processedMessages.add(messageNumber);
+                }
+                if (!producerTask.isStopped() && (consumerIdThatWokeup.get() != null) && (consumerIdThatWokeup.get().equals(event.getConsumerId()))) {
+                    LOG.debug("Signal producer to stop");
+                    producerTask.stop();
+                    waitForProducerToStop();
+                    if (producerTask.isStopped()) {
+                        totalMessages = producerTask.getTotalMessages();
+                    }
+                }
+                break;
+            }
+            case POLL: {
+                if ((totalMessages != null) && (processedMessages.size() >= totalMessages)) {
+                    // we're done!
+                    consumers.forEach(Consumer::wakeup);
+                }
+                break;
+            }
+            case WAKING_UP: {
+                consumerIdThatWokeup.set(event.getConsumerId());
+
+                break;
+            }
+/*
+        The producer should finish:
+            - Once we've woken up
+            &&
+           - There's a message from the same consumerId, which implies a rebalance occurred
+
+           Then you must signal the producer.setTotalMessages to shutdown, and wait for it to finish
+           Then the consumers can in turn be shut downn during POLL, if we've met the totalMessages
+
+
+ */
+        }
+    }
+
+    private void waitForProducerToStop() {
+        // spin locking is evil, and I probably should do message passing instead
+        while (!producerTask.isStopped()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/ConsumedEvent.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/ConsumedEvent.java
@@ -1,0 +1,59 @@
+package com.opentable.kafka.session;
+
+import java.util.UUID;
+
+// Each event consumed by EventBus or emitted as listener
+public class ConsumedEvent<T> {
+
+    private final UUID consumerId;
+    private final int messageNumber;
+    private final T message;
+    private final EventType eventType;
+    private final int partition;
+    private final long offset;
+
+    public ConsumedEvent(final UUID consumerId, final T message, final EventType eventType, int messageNumber, int partition, long offset) {
+        this.consumerId = consumerId;
+        this.message = message;
+        this.eventType = eventType;
+        this.offset = offset;
+        this.partition = partition;
+        this.messageNumber = messageNumber;
+    }
+
+    public int getMessageNumber() {
+        return messageNumber;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public T getMessage() {
+        return message;
+    }
+
+    public UUID getConsumerId() {
+        return consumerId;
+    }
+
+    public enum EventType {
+        SUBSCRIBED,
+        MESSAGE,
+        ABOUT_TO_SLEEP,
+        WAKING_UP, POLL, CLOSING
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ConsumedEvent{");
+        sb.append("consumerId=").append(consumerId);
+        sb.append(", messageNumber=").append(messageNumber);
+        sb.append(", message=").append(message);
+        sb.append(", eventType=").append(eventType);
+        sb.append(", partition=").append(partition);
+        sb.append(", offset=").append(offset);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/ConsumerTask.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/ConsumerTask.java
@@ -1,0 +1,135 @@
+package com.opentable.kafka.session;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConsumerTask<T> implements Runnable {
+    private static final Logger LOG  = LoggerFactory.getLogger(ConsumerTask.class);
+
+    private final Consumer<Integer, T> consumer;
+    private final String topic;
+    private final AtomicInteger consumedEvents = new AtomicInteger();
+    private volatile boolean running = true;
+    private final EventBus<T> eventBus;
+    private final Integer sleepPoint;
+    private final UUID consumerId = UUID.randomUUID();
+    private final BiConsumer<Runnable, Consumer<Integer, T>> recoveryLambda;
+
+    private final AtomicInteger revocations = new AtomicInteger();
+    private final AtomicInteger emptyRevocations = new AtomicInteger();
+
+
+    public ConsumerTask(final EventBus<T> eventBus, final Consumer<Integer, T> consumer, final String topic,
+                        final Integer sleepPoint, final BiConsumer<Runnable, Consumer<Integer, T>> recoveryLambda) {
+        this.consumer = consumer;
+        this.topic = topic;
+        this.sleepPoint = sleepPoint;
+        this.eventBus = eventBus;
+        this.recoveryLambda = recoveryLambda;
+        subscribe();
+        eventBus.send(new ConsumedEvent<>(consumerId, null, ConsumedEvent.EventType.SUBSCRIBED, -1, -1, -1));
+    }
+
+    public int getEmptyRevocations() {
+        return emptyRevocations.get();
+    }
+
+    private void subscribe() {
+        consumer.subscribe(Collections.singletonList(topic), new ConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+                if (!partitions.isEmpty()) {
+                    revocations.incrementAndGet();
+                    LOG.warn("OTPARTITION Revoke ({}) - {}", consumerId, partitions);
+                } else {
+                    emptyRevocations.incrementAndGet();
+                }
+            }
+
+            @Override
+            public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+                if (!partitions.isEmpty()) {
+                    LOG.warn("OTPARTITION Assign ({}) - {}", consumerId, partitions);
+                }
+            }
+        });
+    }
+
+    public void stop() {
+        running = false;
+        consumer.wakeup();
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (getMayRun()) {
+                tick();
+            }
+        } catch (WakeupException e) {
+            running = false;
+        } finally {
+            eventBus.send(new ConsumedEvent<>(consumerId, null, ConsumedEvent.EventType.CLOSING, consumedEvents.get(), -1, -1));
+            consumer.close();
+        }
+    }
+
+    private void tick() {
+        eventBus.send(new ConsumedEvent<>(consumerId, null, ConsumedEvent.EventType.POLL, consumedEvents.get(), -1, -1));
+        // shows this idiom is safe even on freshly subscribed
+        consumer.resume(consumer.paused());
+        ConsumerRecords<Integer, T> records = consumer.poll(Duration.ofMillis(500));
+        if (!records.isEmpty()) {
+            // Again, mostly proving this no-op works
+            consumer.pause(consumer.assignment());
+            process(records);
+        }
+    }
+
+    private void process(final ConsumerRecords<Integer, T> records) {
+        // Because max Poll records == 1, this should only return 1
+        if (records.count() != 1) {
+            throw new IllegalStateException("Only 1");
+        }
+        for (ConsumerRecord<Integer, T> record : records) {
+            if (getMayRun()) {
+                int howManyRecordsIveConsumed = consumedEvents.incrementAndGet();
+                LOG.info("{} processed {} records", consumerId, howManyRecordsIveConsumed);
+                eventBus.send(new ConsumedEvent<>(consumerId, record.value(), ConsumedEvent.EventType.MESSAGE, record.key(), record.partition(), record.offset()));
+
+                if (sleepPoint != null && howManyRecordsIveConsumed == sleepPoint) {
+                    eventBus.send(new ConsumedEvent<>(consumerId, record.value(), ConsumedEvent.EventType.ABOUT_TO_SLEEP, record.key(), record.partition(), record.offset()));
+                    LOG.info("Calling sleep point");
+                    this.recoveryLambda.accept(this::subscribe, consumer);
+                    eventBus.send(new ConsumedEvent<>(consumerId, record.value(), ConsumedEvent.EventType.WAKING_UP, record.key(), record.partition(), record.offset()));
+                }
+                break;
+            }
+        }
+    }
+
+    public UUID getConsumerId() {
+        return consumerId;
+    }
+
+    public int getRevocations() {
+        return revocations.get();
+    }
+
+    private boolean getMayRun() {
+        return running && !Thread.currentThread().isInterrupted();
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/EventBus.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/EventBus.java
@@ -1,0 +1,35 @@
+package com.opentable.kafka.session;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * This merely collects the events...
+ * @param <T>
+ */
+public class EventBus<T> {
+    public static interface Listener<T> {
+        void listen(ConsumedEvent<T> event);
+    }
+
+    private final List<Listener<T>> listeners = new CopyOnWriteArrayList<>();
+    private final List<ConsumedEvent<T>> events = new ArrayList<>();
+
+    public void send(ConsumedEvent<T> event) {
+        synchronized (events) {
+            events.add(event);
+            listeners.forEach(t -> t.listen(event));
+        }
+    }
+
+    public void addListener(Listener<T> listener) {
+        listeners.add(listener);
+    }
+
+    public List<ConsumedEvent<T>> getEvents() {
+        synchronized(events) {
+            return new ArrayList<>(events);
+        }
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/ProducerTask.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/ProducerTask.java
@@ -1,0 +1,78 @@
+package com.opentable.kafka.session;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProducerTask implements Runnable {
+    private final static Logger LOG = LoggerFactory.getLogger(ProducerTask.class);
+    final private Producer<Integer, String> producer;
+    final private String topic;
+    final private AtomicInteger producedMessages = new AtomicInteger();
+    private volatile boolean running = true;
+    private volatile boolean isStopped = false;
+    private volatile Integer maxRecords;
+
+    public ProducerTask(Producer<Integer, String> producer, String topic, Integer maxRecords) {
+        this.producer = producer;
+        this.maxRecords = maxRecords;
+        this.topic = topic;
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (mayRun()) {
+                produce();
+            }
+        } finally {
+            producer.close(1, TimeUnit.MINUTES);
+            isStopped = true;
+        }
+
+        LOG.info("Producer shutting down");
+    }
+
+    public void stop() {
+        running = false;
+    }
+
+    public boolean isStopped() {
+        return isStopped;
+    }
+
+    public void setMaxRecords(final Integer maxRecords) {
+        this.maxRecords = maxRecords;
+    }
+
+    private void produce() {
+        try {
+            long produced = producedMessages.incrementAndGet();
+            // synchronous send
+            producer.send(new ProducerRecord<>(topic, (int) produced, "produced" + produced)).get();
+            // Besides mayRun() - which could be called externally or via future.cancel, this terminates as follows
+            // If maxRecords is set, then we'll stop at >= maxRecords
+            if ((maxRecords != null) && (maxRecords > 0) && (produced >= maxRecords)) {
+                LOG.info("Stopping after producing {}", produced);
+                running = false;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    private boolean mayRun() {
+        return running && !Thread.currentThread().isInterrupted();
+    }
+
+    public int getTotalMessages() {
+        return producedMessages.get();
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/SimpleBoundedListener.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/SimpleBoundedListener.java
@@ -1,0 +1,50 @@
+package com.opentable.kafka.session;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Assumes that a final message count is sufficient to trigger the shutdown
+ * @param <T>
+ */
+public class SimpleBoundedListener<T> implements EventBus.Listener<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleBoundedListener.class);
+
+    private volatile Integer totalMessages;
+    private final List<Consumer<Integer, String>> consumers;
+    private final Set<Integer> processedMessages = ConcurrentHashMap.newKeySet();
+
+    public SimpleBoundedListener(Integer totalMessages, Consumer<Integer, String> consumers) {
+        this(totalMessages, Collections.singletonList(consumers));
+    }
+    public SimpleBoundedListener(Integer totalMessages, List<Consumer<Integer, String>> consumers) {
+        this.totalMessages = totalMessages;
+        this.consumers = consumers;
+    }
+    @Override
+    public void listen(final ConsumedEvent<T> event) {
+        LOG.debug("listener: {} ",  event);
+        int messageNumber = event.getMessageNumber();
+        switch (event.getEventType()) {
+            case MESSAGE: {
+                if (messageNumber > 0) {
+                    processedMessages.add(messageNumber);
+                }
+                break;
+            }
+            case POLL: {
+                if ((totalMessages != null) && (processedMessages.size() == totalMessages)) {
+                    // we're done!
+                    consumers.forEach(Consumer::wakeup);
+                }
+                break;
+            }
+        }
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/SleepingRecoveryLambda.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/SleepingRecoveryLambda.java
@@ -1,0 +1,27 @@
+package com.opentable.kafka.session;
+
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SleepingRecoveryLambda implements BiConsumer<Runnable, Consumer<Integer, String>> {
+    private static final Logger LOG = LoggerFactory.getLogger(SleepingRecoveryLambda.class);
+
+    private final long sleepMillis;
+
+    public SleepingRecoveryLambda(final long sleepMillis) {
+        this.sleepMillis = sleepMillis;
+    }
+
+    @Override
+    public void accept(final Runnable noop, final Consumer<Integer, String> kafkaConsumer) {
+        LOG.info("Sleeping for {} ms, rebalance should occur...", sleepMillis);
+        try {
+            Thread.sleep(sleepMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/SleepingSessionTest.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/SleepingSessionTest.java
@@ -1,0 +1,35 @@
+package com.opentable.kafka.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+
+public class SleepingSessionTest extends BaseSessionTest {
+
+    @Override
+    public BiConsumer<Runnable, Consumer<Integer, String>> getConsumerRecoveryLambda() {
+        return new SleepingRecoveryLambda(12000);
+    }
+
+    @Override
+    public void moreAssertionsForTestResult(final boolean withSleep, final TestResult testResult, final long expectedTotalMessages, final long expectedRevocations) {
+        List<ConsumedEvent.EventType> eventTypes = testResult.getEvents().stream().map(ConsumedEvent::getEventType).collect(Collectors.toList());
+        Optional<ConsumedEvent<String>> consumerThatWokeup = testResult.getEvents().stream().filter(t -> t.getEventType() == ConsumedEvent.EventType.WAKING_UP).findFirst();
+        assertThat(consumerThatWokeup.isPresent()).isEqualTo(withSleep);
+        assertThat(eventTypes.stream().filter(t -> t == ConsumedEvent.EventType.MESSAGE).count()).isEqualTo(expectedTotalMessages);
+        long revocations = 0;
+        if (!withSleep) {
+            revocations = testResult.getConsumerTaskList().stream().mapToLong(ConsumerTask::getRevocations).sum();
+        } else {
+            revocations = testResult.getConsumerTaskList().stream().filter(t -> t.getConsumerId().equals(consumerThatWokeup.get().getConsumerId())).collect(Collectors.toList()).stream()
+                    .mapToLong(ConsumerTask::getRevocations).sum();
+        }
+        assertThat(revocations).isEqualTo(expectedRevocations);
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/TestResult.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/TestResult.java
@@ -1,0 +1,27 @@
+package com.opentable.kafka.session;
+
+import java.util.List;
+
+public class TestResult {
+    private final List<ConsumedEvent<String>> events;
+    private final List<ConsumerTask<String>> consumerTaskList;
+    private final ProducerTask producerTask;
+
+    public TestResult(final List<ConsumerTask<String>> consumerTaskList, final List<ConsumedEvent<String>> events, final ProducerTask producerTask) {
+        this.events = events;
+        this.consumerTaskList = consumerTaskList;
+        this.producerTask = producerTask;
+    }
+
+    public List<ConsumerTask<String>> getConsumerTaskList() {
+        return consumerTaskList;
+    }
+
+    public List<ConsumedEvent<String>> getEvents() {
+        return events;
+    }
+
+    public ProducerTask getProducerTask() {
+        return producerTask;
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/UnsubscribingRecoveryLambda.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/UnsubscribingRecoveryLambda.java
@@ -1,0 +1,29 @@
+package com.opentable.kafka.session;
+
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UnsubscribingRecoveryLambda implements BiConsumer<Runnable, Consumer<Integer, String>> {
+    private static final Logger LOG = LoggerFactory.getLogger(UnsubscribingRecoveryLambda.class);
+
+    private final long sleepMillis;
+
+    public UnsubscribingRecoveryLambda(final long sleepMillis) {
+        this.sleepMillis = sleepMillis;
+    }
+
+    @Override
+    public void accept(final Runnable subscriber, final Consumer<Integer, String> kafkaConsumer) {
+        LOG.info("Unsubscribing for [} ms, rebalance should occur...", sleepMillis);
+        try {
+            kafkaConsumer.unsubscribe();
+            Thread.sleep(sleepMillis);
+            subscriber.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/otj-kafka/src/test/java/com/opentable/kafka/session/UnsubscribingSessionTest.java
+++ b/otj-kafka/src/test/java/com/opentable/kafka/session/UnsubscribingSessionTest.java
@@ -1,0 +1,40 @@
+package com.opentable.kafka.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+public class UnsubscribingSessionTest extends BaseSessionTest {
+
+    @Override
+    public BiConsumer<Runnable, Consumer<Integer, String>> getConsumerRecoveryLambda() {
+        return new UnsubscribingRecoveryLambda(12000L);
+    }
+
+    @Override
+    public void moreAssertionsForTestResult(final boolean withSleep, final TestResult testResult, final long expectedTotalMessages, final long expectedRevocations) {
+        List<ConsumedEvent.EventType> eventTypes = testResult.getEvents().stream().map(ConsumedEvent::getEventType).collect(Collectors.toList());
+        Optional<ConsumedEvent<String>> consumerThatWokeup = testResult.getEvents().stream().filter(t -> t.getEventType() == ConsumedEvent.EventType.WAKING_UP).findFirst();
+        assertThat(consumerThatWokeup.isPresent()).isEqualTo(withSleep);
+        assertThat(eventTypes.stream().filter(t -> t == ConsumedEvent.EventType.MESSAGE).count()).isEqualTo(expectedTotalMessages);
+        long revocations;
+        if (!withSleep) {
+            revocations = testResult.getConsumerTaskList().stream().mapToLong(ConsumerTask::getRevocations).sum();
+        } else {
+            //STILL DOESNT work well... I get 2 per every consumer EXCEPT the original. Does this make sense - maybe because it's unsubscribed
+            // I chcked the code - indeed revoke will be called with an empty set, which makes the math "hard"
+            List<ConsumerTask<String>> wokeup = testResult.getConsumerTaskList().stream().filter(t -> t.getConsumerId().equals(consumerThatWokeup.get().getConsumerId())).collect(Collectors.toList());
+            revocations = wokeup.stream()
+                    .mapToLong(ConsumerTask::getRevocations).sum();
+            long empty  = wokeup.stream().mapToLong(ConsumerTask::getEmptyRevocations).sum();
+            revocations += empty;
+            revocations --; // This compensates for original one
+        }
+        assertThat(revocations).isEqualTo(expectedRevocations);
+    }
+}


### PR DESCRIPTION
See https://github.com/opentable/ot-eda-java/pull/152

The session tests are tests of kafka core functionality and not related to EDA.

The contents of these additions were already reviewed and approved in a previous PR in ot-eda-java. This PR is just moving them to a better home without making any functional changes.